### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/locale.js
+++ b/assets/js/locale.js
@@ -5,6 +5,11 @@ $(document).ready(function() {
 });
 
 function loadLanguage(lang) {
+  const allowedLangs = ["en", "es", "fr", "de"]; // Add all allowed language codes here
+  if (!allowedLangs.includes(lang)) {
+    console.error("Invalid language code");
+    return;
+  }
   base_pathname = window.location.pathname.replace(/\/[a-z]+([_-][a-z]+)?\//, "/")
   if (lang === "en") {
     url = base_pathname


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Open-Source-Guides/security/code-scanning/2](https://github.com/Git-Hub-Chris/Open-Source-Guides/security/code-scanning/2)

To fix the problem, we need to ensure that the `lang` value is properly validated or sanitized before it is used to construct the URL. The best way to fix this issue is to validate the `lang` value against a list of allowed language codes. This ensures that only valid and expected language codes are used, preventing any malicious input from being processed.

We will:
1. Define a list of allowed language codes.
2. Check if the `lang` value is in the list of allowed language codes before constructing the URL.
3. If the `lang` value is not valid, we can either set a default value or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
