### PR TITLE
Potential fix for code scanning alert no. 1: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/jekyll-preview.yml
+++ b/.github/workflows/jekyll-preview.yml
@@ -7,7 +7,7 @@
 name: Deploy Jekyll site to Pages preview environment
 on:
   # Runs on pull requests targeting the default branch
-  pull_request_target:
+  pull_request:
     branches: ["main"]
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Open-Source-Guides/security/code-scanning/1](https://github.com/Git-Hub-Chris/Open-Source-Guides/security/code-scanning/1)

To fix the problem, we need to ensure that untrusted code from pull requests does not run with elevated privileges in the context of the default branch. Instead of using `pull_request_target`, we should use `pull_request` to run the workflow in the context of the pull request branch. This will prevent untrusted code from having access to the default branch's context and permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
